### PR TITLE
Fix import for burst compiler

### DIFF
--- a/EdgegapGen2SDK.asmdef
+++ b/EdgegapGen2SDK.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Edgegap.Gen2.SDK, Version=1.1.0, Culture=neutral",
+    "name": "Edgegap.Gen2.SDK",
     "rootNamespace": "",
     "references": [],
     "includePlatforms": [],


### PR DESCRIPTION
strip version and culture from assembly name